### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ evennia start
 git clone https://github.com/InspectorCaracal/evennia-minimud.git
 cd evennia-minimud
 python -m venv venv
-./venv/scripts/activate
+source venv/bin/activate
 pip install .
 evennia migrate
 evennia start


### PR DESCRIPTION
Adjust venv activation instruction in README for linux/mac (can't confirm on mac, but prior provided instruction didn't work for linux)