### PR TITLE
Fix the scipy version to the same as in evennia contrib. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     'pywin32; sys_platform=="win32"',
 
     # contrib requirements
-    "scipy"
+    "scipy == 1.9.3"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
 More modern versions of scipy (1.12 tested) moved zeros to optimize.zeros requiring the future adjustment of the xyzmap_legend.py's import to also change.  

This modification should lock the version to the same version as in the evennia project currently requires.